### PR TITLE
Update ScanProsite.py

### DIFF
--- a/Bio/ExPASy/ScanProsite.py
+++ b/Bio/ExPASy/ScanProsite.py
@@ -59,7 +59,7 @@ def scan(seq="", mirror="https://prosite.expasy.org", output="xml", **keywords):
         if value is not None:
             parameters[key] = value
     command = urlencode(parameters)
-    url = f"{mirror}/cgi-bin/prosite/PSScan.cgi?{command}"
+    url = f"{mirror}/cgi-bin/prosite/scanprosite/PSScan.cgi?{command}"
     handle = urlopen(url)
     return handle
 


### PR DESCRIPTION
Updated scanprosite url

Was : https://prosite.expasy.org/cgi-bin/prosite/PSScan.cgi?
This version was causing issue : "urllib.error.HTTPError: HTTP Error 308: Permanent Redirect "

Based on ScanProsite documentation it should be : https://prosite.expasy.org/cgi-bin/prosite/scanprosite/PSScan.cgi?

Source : https://prosite.expasy.org/scanprosite/scanprosite_doc.html#rest

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
